### PR TITLE
Add parallax background and fade transitions to auth flows

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,7 +2,8 @@ import { Toaster } from "@/components/ui/toaster";
 import { Toaster as Sonner } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { BrowserRouter, Routes, Route } from "react-router-dom";
+import { BrowserRouter, Routes, Route, useLocation } from "react-router-dom";
+import { AnimatePresence } from "framer-motion";
 import { AuthProvider } from "./hooks/useAuth";
 import { ProtectedRoute } from "./components/ProtectedRoute";
 import { AdminRoute } from "./components/AdminRoute";
@@ -37,6 +38,100 @@ import PaymentSuccess from "./pages/PaymentSuccess";
 
 const queryClient = new QueryClient();
 
+const AppRoutes = () => {
+  const location = useLocation();
+  return (
+    <AnimatePresence mode="wait">
+      <Routes location={location} key={location.pathname}>
+        {/* Simple Home as Homepage */}
+        {/* CLEAN ROUTES - Only existing pages */}
+        <Route path="/" element={<SimpleVipEntry />} />
+        <Route path="/SimpleVipEntry" element={<SimpleVipEntry />} />
+        <Route path="/test" element={<TestPage />} />
+        <Route path="/vip" element={<VipEntry />} />
+        <Route path="/signin" element={<SignIn />} />
+        <Route path="/login" element={<SignIn />} />
+        <Route path="/register" element={<Register />} />
+        <Route path="/signup" element={<Register />} />
+        <Route path="/auth/callback" element={<SimpleAuthCallback />} />
+        <Route path="/AuthCallback" element={<SimpleAuthCallback />} />
+        <Route path="/discover" element={<Discover />} />
+        <Route path="/feed" element={<Feed />} />
+        <Route path="/reels" element={
+          <ProtectedRoute>
+            <Reels />
+          </ProtectedRoute>
+        } />
+        <Route path="/creator/:username" element={<CreatorProfile />} />
+        <Route path="/agency" element={<Agency />} />
+        <Route path="/creator-application" element={
+          <ProtectedRoute>
+            <CreatorApplication />
+          </ProtectedRoute>
+        } />
+        <Route path="/analytics" element={<AnalyticsDashboard />} />
+        <Route path="/AnalyticsDashboard" element={<AnalyticsDashboard />} />
+        <Route path="/referrals" element={
+          <ProtectedRoute>
+            <ReferralProgram />
+          </ProtectedRoute>
+        } />
+        <Route path="/admin" element={
+          <AdminRoute>
+            <AdminDashboard />
+          </AdminRoute>
+        } />
+        <Route path="/creator-dashboard" element={
+          <ProtectedRoute>
+            <CreatorDashboard />
+          </ProtectedRoute>
+        } />
+        <Route path="/content-manager" element={
+          <ProtectedRoute>
+            <ContentManager />
+          </ProtectedRoute>
+        } />
+        <Route path="/subscription-plans" element={<SubscriptionPlans />} />
+        <Route path="/payment-success" element={<PaymentSuccess />} />
+        <Route path="/PaymentSuccess" element={<PaymentSuccess />} />
+        <Route path="/landing" element={<LandingPage />} />
+        <Route path="/LandingPage" element={<LandingPage />} />
+        <Route path="/messages" element={
+          <ProtectedRoute>
+            <Messages />
+          </ProtectedRoute>
+        } />
+        <Route path="/Messages" element={
+          <ProtectedRoute>
+            <Messages />
+          </ProtectedRoute>
+        } />
+        <Route path="/billing" element={
+          <ProtectedRoute>
+            <Billing />
+          </ProtectedRoute>
+        } />
+        <Route path="/Billing" element={
+          <ProtectedRoute>
+            <Billing />
+          </ProtectedRoute>
+        } />
+        <Route path="/settings" element={
+          <ProtectedRoute>
+            <Settings />
+          </ProtectedRoute>
+        } />
+        <Route path="/Settings" element={
+          <ProtectedRoute>
+            <Settings />
+          </ProtectedRoute>
+        } />
+        <Route path="*" element={<NotFound />} />
+      </Routes>
+    </AnimatePresence>
+  );
+};
+
 
 const App = () => (
   <QueryClientProvider client={queryClient}>
@@ -45,92 +140,7 @@ const App = () => (
         <Toaster />
         <Sonner />
         <BrowserRouter>
-          <Routes>
-            {/* Simple Home as Homepage */}
-            {/* CLEAN ROUTES - Only existing pages */}
-            <Route path="/" element={<SimpleVipEntry />} />
-            <Route path="/SimpleVipEntry" element={<SimpleVipEntry />} />
-            <Route path="/test" element={<TestPage />} />
-            <Route path="/vip" element={<VipEntry />} />
-            <Route path="/signin" element={<SignIn />} />
-            <Route path="/login" element={<SignIn />} />
-            <Route path="/register" element={<Register />} />
-            <Route path="/signup" element={<Register />} />
-            <Route path="/auth/callback" element={<SimpleAuthCallback />} />
-            <Route path="/AuthCallback" element={<SimpleAuthCallback />} />
-            <Route path="/discover" element={<Discover />} />
-            <Route path="/feed" element={<Feed />} />
-            <Route path="/reels" element={
-              <ProtectedRoute>
-                <Reels />
-              </ProtectedRoute>
-            } />
-            <Route path="/creator/:username" element={<CreatorProfile />} />
-            <Route path="/agency" element={<Agency />} />
-            <Route path="/creator-application" element={
-              <ProtectedRoute>
-                <CreatorApplication />
-              </ProtectedRoute>
-            } />
-            <Route path="/analytics" element={<AnalyticsDashboard />} />
-            <Route path="/AnalyticsDashboard" element={<AnalyticsDashboard />} />
-            <Route path="/referrals" element={
-              <ProtectedRoute>
-                <ReferralProgram />
-              </ProtectedRoute>
-            } />
-            <Route path="/admin" element={
-              <AdminRoute>
-                <AdminDashboard />
-              </AdminRoute>
-            } />
-            <Route path="/creator-dashboard" element={
-              <ProtectedRoute>
-                <CreatorDashboard />
-              </ProtectedRoute>
-            } />
-            <Route path="/content-manager" element={
-              <ProtectedRoute>
-                <ContentManager />
-              </ProtectedRoute>
-            } />
-            <Route path="/subscription-plans" element={<SubscriptionPlans />} />
-            <Route path="/payment-success" element={<PaymentSuccess />} />
-            <Route path="/PaymentSuccess" element={<PaymentSuccess />} />
-            <Route path="/landing" element={<LandingPage />} />
-            <Route path="/LandingPage" element={<LandingPage />} />
-            <Route path="/messages" element={
-              <ProtectedRoute>
-                <Messages />
-              </ProtectedRoute>
-            } />
-            <Route path="/Messages" element={
-              <ProtectedRoute>
-                <Messages />
-              </ProtectedRoute>
-            } />
-            <Route path="/billing" element={
-              <ProtectedRoute>
-                <Billing />
-              </ProtectedRoute>
-            } />
-            <Route path="/Billing" element={
-              <ProtectedRoute>
-                <Billing />
-              </ProtectedRoute>
-            } />
-            <Route path="/settings" element={
-              <ProtectedRoute>
-                <Settings />
-              </ProtectedRoute>
-            } />
-            <Route path="/Settings" element={
-              <ProtectedRoute>
-                <Settings />
-              </ProtectedRoute>
-            } />
-            <Route path="*" element={<NotFound />} />
-          </Routes>
+          <AppRoutes />
         </BrowserRouter>
       </TooltipProvider>
     </AuthProvider>

--- a/src/components/ParallaxBackground.tsx
+++ b/src/components/ParallaxBackground.tsx
@@ -1,0 +1,33 @@
+import { useEffect, useRef } from 'react'
+
+/**
+ * Parallax background component that moves slower than scroll.
+ * Uses a fixed gradient to maintain the Cabana aesthetic.
+ */
+export function ParallaxBackground() {
+  const ref = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const handleScroll = () => {
+      if (ref.current) {
+        ref.current.style.transform = `translateY(${window.scrollY * 0.3}px)`
+      }
+    }
+
+    window.addEventListener('scroll', handleScroll, { passive: true })
+    return () => window.removeEventListener('scroll', handleScroll)
+  }, [])
+
+  return (
+    <div className="fixed inset-0 -z-10 overflow-hidden">
+      <div
+        ref={ref}
+        className="absolute inset-0"
+        style={{
+          background:
+            'linear-gradient(135deg, #0A0B14 0%, #1A0B2E 20%, #C77DFF 40%, #FF006E 60%, #B400FF 80%, #0A0B14 100%)',
+        }}
+      />
+    </div>
+  )
+}

--- a/src/pages/PaymentSuccess.tsx
+++ b/src/pages/PaymentSuccess.tsx
@@ -1,10 +1,12 @@
 import React, { useEffect, useState } from 'react'
 import { useNavigate, useSearchParams } from 'react-router-dom'
+import { motion } from 'framer-motion'
 import { CheckCircle, Crown, Gift, Sparkles, ArrowRight, Home, User } from 'lucide-react'
 import { useAuth } from '@/hooks/useAuthSystem'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
+import { ParallaxBackground } from '@/components/ParallaxBackground'
 
 export default function PaymentSuccess() {
   const navigate = useNavigate()
@@ -44,8 +46,14 @@ export default function PaymentSuccess() {
   ]
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-background via-background/80 to-background flex items-center justify-center p-4">
-      <div className="w-full max-w-2xl space-y-8">
+    <div className="relative min-h-screen flex items-center justify-center p-4 text-white overflow-hidden">
+      <ParallaxBackground />
+      <motion.div
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        exit={{ opacity: 0 }}
+        className="w-full max-w-2xl space-y-8"
+      >
         
         {/* Success Animation */}
         <div className="text-center">
@@ -188,7 +196,7 @@ export default function PaymentSuccess() {
             📧 A receipt has been sent to your email address
           </p>
         </div>
-      </div>
+      </motion.div>
     </div>
   )
 }

--- a/src/pages/Register.tsx
+++ b/src/pages/Register.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from "react";
 import { Link, useLocation, useNavigate } from "react-router-dom";
+import { motion } from "framer-motion";
 import { Eye, EyeOff, Crown, Heart, ArrowLeft, CheckCircle, Sparkles, Users, DollarSign, Star } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -7,6 +8,7 @@ import { Label } from "@/components/ui/label";
 import { Checkbox } from "@/components/ui/checkbox";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { useAuth } from "@/hooks/useAuth";
+import { ParallaxBackground } from "@/components/ParallaxBackground";
 
 type Step = 'role' | 'details' | 'verification';
 
@@ -72,8 +74,14 @@ export default function Register() {
 
   if (step === 'role') {
     return (
-      <div className="min-h-screen bg-background flex items-center justify-center px-4">
-        <div className="w-full max-w-md">
+      <div className="relative min-h-screen bg-background flex items-center justify-center px-4 overflow-hidden">
+        <ParallaxBackground />
+        <motion.div
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          className="w-full max-w-md"
+        >
           <div className="text-center mb-8">
             <h1 className="text-4xl font-bold text-gradient mb-4">Join Cabana</h1>
             <p className="text-muted-foreground text-lg">
@@ -259,15 +267,21 @@ export default function Register() {
               </Link>
             </p>
           </div>
-        </div>
+        </motion.div>
       </div>
     );
   }
 
   if (step === 'details') {
     return (
-      <div className="min-h-screen bg-background flex items-center justify-center px-4 py-8">
-        <div className="w-full max-w-md">
+      <div className="relative min-h-screen bg-background flex items-center justify-center px-4 py-8 overflow-hidden">
+        <ParallaxBackground />
+        <motion.div
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          className="w-full max-w-md"
+        >
           <div className="flex items-center gap-4 mb-8">
             <Button 
               variant="ghost" 
@@ -448,15 +462,21 @@ export default function Register() {
               Create Account
             </Button>
           </form>
-        </div>
+        </motion.div>
       </div>
     );
   }
 
   // Verification step
   return (
-    <div className="min-h-screen bg-background flex items-center justify-center px-4">
-      <div className="w-full max-w-md text-center">
+    <div className="relative min-h-screen bg-background flex items-center justify-center px-4 overflow-hidden">
+      <ParallaxBackground />
+      <motion.div
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        exit={{ opacity: 0 }}
+        className="w-full max-w-md text-center"
+      >
         <div className="card-luxury">
           <div className="bg-gradient-primary p-4 rounded-full w-20 h-20 mx-auto mb-6 flex items-center justify-center">
             <CheckCircle className="w-10 h-10 text-white" />
@@ -481,7 +501,7 @@ export default function Register() {
             </Button>
           </div>
         </div>
-      </div>
+      </motion.div>
     </div>
   );
 }

--- a/src/pages/SignIn.tsx
+++ b/src/pages/SignIn.tsx
@@ -7,6 +7,7 @@ import { Input } from '@/components/ui/input'
 import { Card } from '@/components/ui/card'
 import { supabase } from '@/integrations/supabase/supabase'
 import { useToast } from '@/hooks/use-toast'
+import { ParallaxBackground } from '@/components/ParallaxBackground'
 
 const SignIn = () => {
   const [email, setEmail] = useState('')
@@ -89,15 +90,12 @@ const SignIn = () => {
   }
 
   return (
-    <div 
-      className="min-h-screen flex items-center justify-center text-white px-4"
-      style={{
-        background: 'linear-gradient(135deg, #0A0B14 0%, #1A0B2E 20%, #C77DFF 40%, #FF006E 60%, #B400FF 80%, #0A0B14 100%)',
-      }}
-    >
+    <div className="relative min-h-screen flex items-center justify-center text-white px-4 overflow-hidden">
+      <ParallaxBackground />
       <motion.div
         initial={{ opacity: 0, scale: 0.95 }}
         animate={{ opacity: 1, scale: 1 }}
+        exit={{ opacity: 0, scale: 0.95 }}
         transition={{ duration: 0.6, ease: "easeOut" }}
         className="w-full max-w-md"
       >


### PR DESCRIPTION
## Summary
- add reusable parallax background component
- apply fade transitions and scrolling parallax to SignIn, Register, and PaymentSuccess pages
- enable route-level fade transitions using `framer-motion`

## Testing
- `npm test` *(fails: Cannot find package 'jsdom')*

------
https://chatgpt.com/codex/tasks/task_e_68a0ba3316e483229e9930c3d25ddfed