### PR TITLE
feat: implement real email capture submission

### DIFF
--- a/src/__tests__/EmailCapture.test.tsx
+++ b/src/__tests__/EmailCapture.test.tsx
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import EmailCapture from '@/components/EmailCapture';
+
+describe('EmailCapture', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('submits email successfully', async () => {
+    const user = userEvent.setup();
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve({}) });
+    global.fetch = fetchMock as any;
+
+    render(<EmailCapture />);
+
+    const input = screen.getByPlaceholderText(/enter your email address/i);
+    await user.type(input, 'test@example.com');
+    const button = screen.getByRole('button');
+
+    await user.click(button);
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledWith('/api/waitlist', expect.any(Object)));
+    await waitFor(() => expect(screen.getByText(/welcome!/i)).toBeInTheDocument());
+    expect(input).toHaveValue('');
+  });
+
+  it('handles submission error', async () => {
+    const user = userEvent.setup();
+    const fetchMock = vi.fn().mockResolvedValue({ ok: false });
+    global.fetch = fetchMock as any;
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    render(<EmailCapture />);
+
+    const input = screen.getByPlaceholderText(/enter your email address/i);
+    await user.type(input, 'test@example.com');
+    const button = screen.getByRole('button');
+
+    await user.click(button);
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    expect(consoleError).toHaveBeenCalled();
+    expect(screen.queryByText(/welcome!/i)).not.toBeInTheDocument();
+    expect(input).toHaveValue('test@example.com');
+
+    consoleError.mockRestore();
+  });
+});
+

--- a/src/components/EmailCapture.tsx
+++ b/src/components/EmailCapture.tsx
@@ -12,17 +12,27 @@ export default function EmailCapture() {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!email) return;
-    
+
     setIsLoading(true);
-    
+
     try {
-      // TODO: Implement actual email capture API call
-      await new Promise(resolve => setTimeout(resolve, 1000)); // Simulate API call
+      const response = await fetch('/api/waitlist', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({ email })
+      });
+
+      if (!response.ok) {
+        throw new Error('Email capture failed');
+      }
+
       setIsSubmitted(true);
-      setEmail("");
+      setEmail('');
       setTimeout(() => setIsSubmitted(false), 3000);
     } catch (error) {
-      console.error("Email capture failed:", error);
+      console.error('Email capture failed:', error);
     } finally {
       setIsLoading(false);
     }


### PR DESCRIPTION
## Summary
- replace placeholder email capture with POST to `/api/waitlist`
- handle success/error states in component
- add unit tests covering successful submission and API error

## Testing
- `pnpm lint` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.5.2.tgz)*
- `pnpm test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.5.2.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_68b101d15eb08322a132f7e3cbfb19a4